### PR TITLE
Add tab based UI for tokens and NFT flow

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -5,11 +5,14 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - rly_network_flutter_sdk (from `.symlinks/plugins/rly_network_flutter_sdk/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
@@ -18,11 +21,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/rly_network_flutter_sdk/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   rly_network_flutter_sdk: db7fbf83b0d979e1fbf95aca994b9c9aac1a0360
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
+  url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
 
 PODFILE CHECKSUM: 70d9d25280d0dd177a5f637cdb0f0b0b12c6a189
 

--- a/app/lib/app_content.dart
+++ b/app/lib/app_content.dart
@@ -14,20 +14,15 @@ class AppContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
+    return (Padding(
       padding: const EdgeInsets.fromLTRB(0, 40, 0, 0),
-      child: Column(
-        children: <Widget>[
-          if (walletAddress == null)
-            WalletCreationScreen(
+      child: walletAddress == null
+          ? WalletCreationScreen(
               setWalletAddress: setWalletAddress,
-            ),
-          if (walletAddress != null)
-            WalletHomeScreen(
-                setWalletAddress: setWalletAddress,
-                walletAddress: walletAddress!)
-        ],
-      ),
-    );
+            )
+          : WalletHomeScreen(
+              setWalletAddress: setWalletAddress,
+              walletAddress: walletAddress!),
+    ));
   }
 }

--- a/app/lib/constants.dart
+++ b/app/lib/constants.dart
@@ -4,6 +4,9 @@ class Constants {
   static const String rpcURL =
       "https://polygon-mumbai.g.alchemy.com/v2/WTW_m3g-DG1oNn8n4Rn0Pb-zHVYa8SgB";
 
+  static const String explorerUrl = "https://mumbai.polygonscan.com";
+  static const String docsUrl = "https://docs.rallyprotocol.com/";
+
   static const String rlyApiKey =
       "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOjQ3fQ.AmObzvqJBFddxgBcLgM-yHb5hPT90sai3SyS_V2ieM1UgHkfroybK-Hc9gpGhUtG1wPBTak6EPSVBJzyl2Z97g";
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -70,12 +70,14 @@ class _AppContainerState extends State<AppContainer> {
         backgroundColor: const Color(0xff22A6FA),
         title: Text(widget.title),
       ),
-      body: _appFinishedLoading
-          ? AppContent(
-              walletAddress: _walletAddress,
-              setWalletAddress: setWalletAddress,
-            )
-          : const AppLoadingScreen(),
+      body: SafeArea(
+        child: _appFinishedLoading
+            ? AppContent(
+                walletAddress: _walletAddress,
+                setWalletAddress: setWalletAddress,
+              )
+            : const AppLoadingScreen(),
+      ),
     );
   }
 }

--- a/app/lib/screens/create_wallet_screen.dart
+++ b/app/lib/screens/create_wallet_screen.dart
@@ -13,21 +13,43 @@ class WalletCreationScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return (Column(children: <Widget>[
-      const Center(
-        child: Text("Welcome, you don't appear to have a wallet",
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontSize: 18.0,
-            )),
-      ),
-      Padding(
-        padding: const EdgeInsets.all(10.0),
-        child: ElevatedButton(
-          onPressed: createWallet,
-          child: const Text('Generate a wallet'),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10.0),
+      child: (Column(children: <Widget>[
+        const Center(
+          child: Text("Welcome!",
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 20.0,
+              )),
         ),
-      ),
-    ]));
+        const Center(
+          child: Text("To get started let's create an EOA",
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 16.0,
+              )),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 10.0),
+          child: ElevatedButton(
+            onPressed: createWallet,
+            child: const Text('Generate a wallet'),
+          ),
+        ),
+        const Center(
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 30.0),
+            child: Text(
+                "This will generate an EOA, encrypt it, store it locally and back up to cloud",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontStyle: FontStyle.italic,
+                  fontSize: 12.0,
+                )),
+          ),
+        )
+      ])),
+    );
   }
 }

--- a/app/lib/screens/wallet_home_screen.dart
+++ b/app/lib/screens/wallet_home_screen.dart
@@ -42,7 +42,7 @@ class WalletHomeScreenState extends State<WalletHomeScreen> {
                   Expanded(
                     child: TabBarView(
                       children: [
-                        const TokenTab(),
+                        TokenTab(walletAddress: widget.walletAddress),
                         NftTab(walletAddress: widget.walletAddress)
                       ],
                     ),

--- a/app/lib/screens/wallet_home_screen.dart
+++ b/app/lib/screens/wallet_home_screen.dart
@@ -69,40 +69,36 @@ class WalletHomeScreenState extends State<WalletHomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return (Column(
-      children: <Widget>[
-        Center(
-          child: Text("Welcome\n${widget.walletAddress}",
-              textAlign: TextAlign.center,
-              style: const TextStyle(
-                fontSize: 18.0,
-              )),
-        ),
-        if (_nftUri != null)
-          Image(
-            image: NetworkImage(_nftUri!),
-            fit: BoxFit.cover,
-          ),
-        if (_nftUri == null && (_balance == null || _balance == 0.0))
-          Padding(
-            padding: const EdgeInsets.all(10.0),
-            child: ElevatedButton(
-              onPressed: mintNFT,
-              child: const Text('mint nft'),
+    return Column(
+      children: [
+        Expanded(
+          child: DefaultTabController(
+            length: 2,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 200),
+              child: const Column(
+                children: [
+                  TabBar(
+                    tabs: [
+                      Tab(
+                        text: "Tokens",
+                      ),
+                      Tab(
+                        text: "NFTs",
+                      )
+                    ],
+                  ),
+                  Expanded(
+                    child: TabBarView(
+                      children: [Text("Tokens"), Text("NFTs")],
+                    ),
+                  )
+                ],
+              ),
             ),
-          ),
-        const Padding(
-          padding: EdgeInsets.all(10.0),
-          child: Text("No Balance"),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(10.0),
-          child: ElevatedButton(
-            onPressed: clearWallet,
-            child: const Text('Delete Existing Wallet'),
           ),
         ),
       ],
-    ));
+    );
   }
 }

--- a/app/lib/screens/wallet_home_screen.dart
+++ b/app/lib/screens/wallet_home_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_example/constants.dart';
 import 'package:flutter_example/main.dart';
 import 'package:flutter_example/services/nft.dart';
+import 'package:flutter_example/widgets/wallet/nft_tab.dart';
 import 'package:flutter_example/widgets/wallet/token_tab.dart';
 import 'package:http/http.dart';
 import 'package:rly_network_flutter_sdk/account.dart';
@@ -60,9 +61,9 @@ class WalletHomeScreenState extends State<WalletHomeScreen> {
             length: 2,
             child: ConstrainedBox(
               constraints: const BoxConstraints(minHeight: 200),
-              child: const Column(
+              child: Column(
                 children: [
-                  TabBar(
+                  const TabBar(
                     tabs: [
                       Tab(
                         text: "Tokens",
@@ -74,7 +75,10 @@ class WalletHomeScreenState extends State<WalletHomeScreen> {
                   ),
                   Expanded(
                     child: TabBarView(
-                      children: [TokenTab(), Text("NFTs")],
+                      children: [
+                        const TokenTab(),
+                        NftTab(walletAddress: widget.walletAddress)
+                      ],
                     ),
                   )
                 ],

--- a/app/lib/screens/wallet_home_screen.dart
+++ b/app/lib/screens/wallet_home_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_example/constants.dart';
 import 'package:flutter_example/main.dart';
 import 'package:flutter_example/services/nft.dart';
+import 'package:flutter_example/widgets/wallet/token_tab.dart';
 import 'package:http/http.dart';
 import 'package:rly_network_flutter_sdk/account.dart';
 import 'package:web3dart/web3dart.dart';
@@ -18,26 +19,9 @@ class WalletHomeScreen extends StatefulWidget {
 }
 
 class WalletHomeScreenState extends State<WalletHomeScreen> {
-  double? _balance;
-  String? _nftUri;
-
-  @override
-  void initState() {
-    super.initState();
-    getBalance();
-  }
-
   Future<void> clearWallet() async {
     AccountsUtil.getInstance().permanentlyDeleteAccount();
     widget.setWalletAddress(null);
-  }
-
-  Future<void> getBalance() async {
-    print("getting balance");
-    double balance = await rlyNetwork.getBalance();
-    setState(() {
-      _balance = balance;
-    });
   }
 
   Future<void> mintNFT() async {
@@ -90,7 +74,7 @@ class WalletHomeScreenState extends State<WalletHomeScreen> {
                   ),
                   Expanded(
                     child: TabBarView(
-                      children: [Text("Tokens"), Text("NFTs")],
+                      children: [TokenTab(), Text("NFTs")],
                     ),
                   )
                 ],

--- a/app/lib/screens/wallet_home_screen.dart
+++ b/app/lib/screens/wallet_home_screen.dart
@@ -1,14 +1,7 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
-import 'package:flutter_example/constants.dart';
-import 'package:flutter_example/main.dart';
-import 'package:flutter_example/services/nft.dart';
 import 'package:flutter_example/widgets/wallet/nft_tab.dart';
 import 'package:flutter_example/widgets/wallet/token_tab.dart';
-import 'package:http/http.dart';
 import 'package:rly_network_flutter_sdk/account.dart';
-import 'package:web3dart/web3dart.dart';
 
 class WalletHomeScreen extends StatefulWidget {
   final void Function(String?) setWalletAddress;
@@ -23,33 +16,6 @@ class WalletHomeScreenState extends State<WalletHomeScreen> {
   Future<void> clearWallet() async {
     AccountsUtil.getInstance().permanentlyDeleteAccount();
     widget.setWalletAddress(null);
-  }
-
-  Future<void> mintNFT() async {
-    var httpClient = Client();
-
-    final provider = Web3Client(Constants.rpcURL, httpClient);
-
-    final NFT nft = NFT(EthereumAddress.fromHex(Constants.nftContractAddress),
-        EthereumAddress.fromHex(widget.walletAddress), provider);
-
-    final nextNFTId = await nft.getCurrentNFTId();
-
-    final gsnTx = await nft.getMintNFTTx();
-
-    final String txHash = await rlyNetwork.relay(gsnTx);
-
-    final String tokenURI = await nft.getTokenURI(nextNFTId);
-
-    final parts = tokenURI.split(",");
-
-    final base64Data = utf8.decode(base64.decode(parts[1]));
-
-    final Map<String, dynamic> json = jsonDecode(base64Data);
-
-    setState(() {
-      _nftUri = json['image'];
-    });
   }
 
   @override

--- a/app/lib/widgets/wallet/nft_tab.dart
+++ b/app/lib/widgets/wallet/nft_tab.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_example/constants.dart';
+import 'package:flutter_example/main.dart';
+import 'package:flutter_example/services/nft.dart';
+import 'package:http/http.dart';
+import 'package:web3dart/web3dart.dart';
+
+class NftTab extends StatefulWidget {
+  final String walletAddress;
+  const NftTab({super.key, required this.walletAddress});
+
+  @override
+  State<StatefulWidget> createState() => NftTabState();
+}
+
+class NftTabState extends State<NftTab> {
+  bool _hasMinted = false;
+  bool _minting = false;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  Future<void> mintNFT() async {
+    setState(() {
+      _minting = true;
+    });
+    var httpClient = Client();
+
+    final provider = Web3Client(Constants.rpcURL, httpClient);
+
+    final NFT nft = NFT(EthereumAddress.fromHex(Constants.nftContractAddress),
+        EthereumAddress.fromHex(widget.walletAddress), provider);
+
+    final nextNFTId = await nft.getCurrentNFTId();
+
+    final gsnTx = await nft.getMintNFTTx();
+
+    final String txHash = await rlyNetwork.relay(gsnTx);
+
+    final String tokenURI = await nft.getTokenURI(nextNFTId);
+
+    setState(() {
+      _hasMinted = true;
+      _minting = false;
+    });
+
+    print("current nft: $nextNFTId");
+    print("tokenURI: $tokenURI");
+    print("txHash: $txHash");
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16.0),
+      child: _minting
+          ? const Column(
+              children: [
+                CircularProgressIndicator(),
+              ],
+            )
+          : Column(
+              children: [if (!_hasMinted) mintNftWidget()],
+            ),
+    );
+  }
+
+  Widget mintNftWidget() {
+    if (_minting) {
+      return (const Column(
+        children: [Text("Claiming RLY..."), CircularProgressIndicator()],
+      ));
+    }
+    return Padding(
+      padding: const EdgeInsets.only(top: 48),
+      child: Column(
+        children: [
+          const Center(
+            child: Text("You don't have an NFT yet.",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 22,
+                )),
+          ),
+          ElevatedButton(
+              onPressed: _minting
+                  ? null
+                  : () {
+                      mintNFT();
+                    },
+              child: const Text("Mint NFT"))
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/widgets/wallet/nft_tab.dart
+++ b/app/lib/widgets/wallet/nft_tab.dart
@@ -136,7 +136,19 @@ class NftTabState extends State<NftTab> {
                   : () {
                       mintNFT();
                     },
-              child: const Text("Mint NFT"))
+              child: const Text("Mint NFT")),
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 12.0, horizontal: 30),
+            child: Center(
+              child: Text(
+                  "This will mint an NFT without user needing any native tokens to pay for gas.",
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontStyle: FontStyle.italic,
+                    fontSize: 12.0,
+                  )),
+            ),
+          )
         ],
       ),
     );

--- a/app/lib/widgets/wallet/nft_tab.dart
+++ b/app/lib/widgets/wallet/nft_tab.dart
@@ -5,6 +5,7 @@ import 'package:flutter_example/constants.dart';
 import 'package:flutter_example/main.dart';
 import 'package:flutter_example/services/nft.dart';
 import 'package:http/http.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:web3dart/web3dart.dart';
 
 class NftTab extends StatefulWidget {
@@ -19,6 +20,7 @@ class NftTabState extends State<NftTab> {
   bool _hasMinted = false;
   bool _minting = false;
   String? _nftUri;
+  String? _txnHash;
 
   @override
   void initState() {
@@ -54,7 +56,15 @@ class NftTabState extends State<NftTab> {
       _hasMinted = true;
       _minting = false;
       _nftUri = json['image'];
+      _txnHash = txHash;
     });
+  }
+
+  Future<void> _showTransactionOnExplorer() async {
+    final Uri explorerUrl = Uri.parse("${Constants.explorerUrl}/tx/$_txnHash");
+    if (!await launchUrl(explorerUrl)) {
+      throw Exception('Could not launch ${explorerUrl.toString()}');
+    }
   }
 
   @override
@@ -99,7 +109,7 @@ class NftTabState extends State<NftTab> {
                 padding: const EdgeInsets.only(top: 10.0),
                 child: TextButton(
                   onPressed: () {
-                    print("Will open browser");
+                    _showTransactionOnExplorer();
                   },
                   child: const Text("view on chain"),
                 )))

--- a/app/lib/widgets/wallet/nft_tab.dart
+++ b/app/lib/widgets/wallet/nft_tab.dart
@@ -110,7 +110,13 @@ class NftTabState extends State<NftTab> {
   Widget mintNftWidget() {
     if (_minting) {
       return (const Column(
-        children: [Text("Minting your NFT..."), CircularProgressIndicator()],
+        children: [
+          Text("Minting your NFT..."),
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: 16.0),
+            child: CircularProgressIndicator(),
+          )
+        ],
       ));
     }
     return Padding(

--- a/app/lib/widgets/wallet/token_tab.dart
+++ b/app/lib/widgets/wallet/token_tab.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_example/main.dart';
+
+class TokenTab extends StatefulWidget {
+  const TokenTab({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => TokenTabState();
+}
+
+class TokenTabState extends State<TokenTab> {
+  double? _balance;
+  bool _loading = false;
+  bool _claimingRly = false;
+
+  @override
+  void initState() {
+    super.initState();
+    getBalance();
+  }
+
+  Future<void> getBalance() async {
+    setState(() {
+      _loading = true;
+    });
+
+    double balance = await rlyNetwork.getBalance();
+
+    setState(() {
+      _balance = balance;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16.0),
+      child: _loading
+          ? const Column(
+              children: [
+                CircularProgressIndicator(),
+              ],
+            )
+          : Column(
+              children: [
+                const Text("\$RLY balance", style: TextStyle(fontSize: 18)),
+                Text(
+                  "$_balance",
+                  style: const TextStyle(fontSize: 24),
+                ),
+                ElevatedButton(
+                    onPressed: getBalance, child: const Text("Refresh")),
+                if (_balance == 0) claimRlyWidget()
+              ],
+            ),
+    );
+  }
+
+  Widget claimRlyWidget() {
+    if (_claimingRly) {
+      return (const Column(
+        children: [Text("Claiming RLY..."), CircularProgressIndicator()],
+      ));
+    }
+    return Padding(
+      padding: const EdgeInsets.only(top: 48),
+      child: Column(
+        children: [
+          const Center(
+            child: Text("Welcome New User to Rally Protocol!",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 28,
+                )),
+          ),
+          ElevatedButton(
+              onPressed: _loading
+                  ? null
+                  : () async {
+                      setState(() {
+                        _claimingRly = true;
+                      });
+                      await rlyNetwork.claimRly();
+                      getBalance();
+                    },
+              child: const Text("Claim Your RLY"))
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/widgets/wallet/token_tab.dart
+++ b/app/lib/widgets/wallet/token_tab.dart
@@ -59,6 +59,14 @@ class TokenTabState extends State<TokenTab> {
   Widget alreadyClaimedUser() {
     return Column(
       children: [
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 10.0),
+          child: Center(
+            child: Text('Congrats you\'ve claimed your gassless erc20 tokens',
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          ),
+        ),
         const Text("\$RLY balance", style: TextStyle(fontSize: 18)),
         Text(
           "$_balance",

--- a/app/lib/widgets/wallet/token_tab.dart
+++ b/app/lib/widgets/wallet/token_tab.dart
@@ -32,59 +32,91 @@ class TokenTabState extends State<TokenTab> {
     });
   }
 
+  Future<void> claimRly() async {
+    setState(() {
+      _claimingRly = true;
+    });
+    await rlyNetwork.claimRly();
+    await getBalance();
+    setState(() {
+      _claimingRly = false;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
+    if (_loading) {
+      return const Center(
+        child: CircularProgressIndicator(),
+      );
+    }
     return Padding(
       padding: const EdgeInsets.only(top: 16.0),
-      child: _loading
-          ? const Column(
-              children: [
-                CircularProgressIndicator(),
-              ],
-            )
-          : Column(
-              children: [
-                const Text("\$RLY balance", style: TextStyle(fontSize: 18)),
-                Text(
-                  "$_balance",
-                  style: const TextStyle(fontSize: 24),
-                ),
-                ElevatedButton(
-                    onPressed: getBalance, child: const Text("Refresh")),
-                if (_balance == 0) claimRlyWidget()
-              ],
-            ),
+      child: _balance == 0 ? claimRlyWidget() : alreadyClaimedUser(),
+    );
+  }
+
+  Widget alreadyClaimedUser() {
+    return Column(
+      children: [
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 10.0),
+          child: Text('Welcome back!', style: TextStyle(fontSize: 20)),
+        ),
+        const Text("\$RLY balance", style: TextStyle(fontSize: 18)),
+        Text(
+          "$_balance",
+          style: const TextStyle(fontSize: 24),
+        ),
+      ],
     );
   }
 
   Widget claimRlyWidget() {
     if (_claimingRly) {
       return (const Column(
-        children: [Text("Claiming RLY..."), CircularProgressIndicator()],
+        children: [
+          Text("Claiming RLY...", style: TextStyle(fontSize: 18)),
+          Padding(
+            padding: EdgeInsets.only(top: 12.0),
+            child: CircularProgressIndicator(),
+          )
+        ],
       ));
     }
     return Padding(
-      padding: const EdgeInsets.only(top: 48),
+      padding: const EdgeInsets.only(top: 12),
       child: Column(
         children: [
           const Center(
             child: Text("Welcome New User to Rally Protocol!",
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  fontSize: 28,
+                  fontSize: 20,
                 )),
           ),
-          ElevatedButton(
-              onPressed: _loading
-                  ? null
-                  : () async {
-                      setState(() {
-                        _claimingRly = true;
-                      });
-                      await rlyNetwork.claimRly();
-                      getBalance();
-                    },
-              child: const Text("Claim Your RLY"))
+          Padding(
+            padding: const EdgeInsets.only(top: 12),
+            child: ElevatedButton(
+                onPressed: _loading
+                    ? null
+                    : () {
+                        claimRly();
+                      },
+                child: const Text("Claim ERC20")),
+          ),
+          const Padding(
+            padding: EdgeInsets.only(top: 12.0),
+            child: Center(
+              child: Text(
+                  "This will claim 10 units of an ERC20 contract without the user needing native tokens in their wallet",
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontStyle: FontStyle.italic,
+                    fontSize: 12.0,
+                  )),
+            ),
+          )
         ],
       ),
     );

--- a/app/lib/widgets/wallet/token_tab.dart
+++ b/app/lib/widgets/wallet/token_tab.dart
@@ -72,6 +72,14 @@ class TokenTabState extends State<TokenTab> {
           "$_balance",
           style: const TextStyle(fontSize: 24),
         ),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 12.0),
+          child: TextButton(
+              onPressed: () {
+                print('will open browser');
+              },
+              child: const Text('view on chain')),
+        )
       ],
     );
   }

--- a/app/lib/widgets/wallet/token_tab.dart
+++ b/app/lib/widgets/wallet/token_tab.dart
@@ -59,10 +59,6 @@ class TokenTabState extends State<TokenTab> {
   Widget alreadyClaimedUser() {
     return Column(
       children: [
-        const Padding(
-          padding: EdgeInsets.symmetric(vertical: 10.0),
-          child: Text('Welcome back!', style: TextStyle(fontSize: 20)),
-        ),
         const Text("\$RLY balance", style: TextStyle(fontSize: 18)),
         Text(
           "$_balance",

--- a/app/lib/widgets/wallet/token_tab.dart
+++ b/app/lib/widgets/wallet/token_tab.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_example/constants.dart';
 import 'package:flutter_example/main.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class TokenTab extends StatefulWidget {
-  const TokenTab({Key? key}) : super(key: key);
+  final String walletAddress;
+  const TokenTab({super.key, required this.walletAddress});
 
   @override
   State<StatefulWidget> createState() => TokenTabState();
@@ -43,6 +46,14 @@ class TokenTabState extends State<TokenTab> {
     });
   }
 
+  Future<void> _showBalanceInExplorer() async {
+    final url = Uri.parse(
+        "${Constants.explorerUrl}/address/${widget.walletAddress}#tokentxns");
+    if (!await launchUrl(url)) {
+      throw Exception('Could not launch $url');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     if (_loading) {
@@ -76,7 +87,7 @@ class TokenTabState extends State<TokenTab> {
           padding: const EdgeInsets.symmetric(vertical: 12.0),
           child: TextButton(
               onPressed: () {
-                print('will open browser');
+                _showBalanceInExplorer();
               },
               child: const Text('view on chain')),
         )

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -325,7 +325,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "1e027df9f0efab703f0b98b8614ec83b1ad10348"
+      resolved-ref: "5c3d1f521ce4f058c9040bdcc401811c07348204"
       url: "https://github.com/rally-dfs/rly-network-flutter-sdk"
     source: git
     version: "0.0.1"

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -470,6 +470,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "47e208a6711459d813ba18af120d9663c20bdf6985d6ad39fe165d2538378d27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.14"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: b04af59516ab45762b2ca6da40fa830d72d0f6045cd97744450b73493fa76330
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "7c65021d5dee51813d652357bc65b8dd4a6177082a9966bc8ba6ee477baa795f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: b651aad005e0cb06a01dbd84b428a301916dc75f0e7ea6165f80057fee2d8e8e
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: b55486791f666e62e0e8ff825e58a023fd6b1f71c49926483f1128d3bbd8fe88
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "95465b39f83bfe95fcb9d174829d6476216f2d548b79c38ab2506e0458787618"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "2942294a500b4fa0b918685aff406773ba0a4cd34b7f42198742a94083020ce5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.20"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "95fef3129dc7cfaba2bc3d5ba2e16063bb561fc6d78e63eee16162bc70029069"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.8"
   uuid:
     dependency: transitive
     description:
@@ -528,4 +592,4 @@ packages:
     version: "1.0.3"
 sdks:
   dart: ">=3.1.3 <4.0.0"
-  flutter: ">=3.7.0"
+  flutter: ">=3.13.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     sdk: flutter
   web3dart: ^2.6.1
   http: ^1.1.0
+  url_launcher: ^6.1.14
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
* App now splits the UX into 2 different sections, 1 for tokens, and 1 for NFTs. 
* Add generally cleaner loading / performing action state. 
* Allow users to view related txns and balances in mumbai exlorer. 
* Cleanup welcome screen language to be more clear about EOAs. 