### PR TITLE
Use shared_preferences to persist NFT mint details

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -338,13 +338,13 @@ packages:
     source: hosted
     version: "1.1.0"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: b7f41bad7e521d205998772545de63ff4e6c97714775902c199353f8bf1511ac
+      sha256: "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   shared_preferences_android:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   web3dart: ^2.6.1
   http: ^1.1.0
   url_launcher: ^6.1.14
+  shared_preferences: ^2.2.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
More efficient than constantly checking chain, and having more complex
NFT contract. This way we just store your prior mint on device in
shared_prefs.
